### PR TITLE
Eventproxy: Attach click events to react main node to prevent unexpected event bubbling 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nebenan-helpers",
-  "version": "4.5.0",
+  "version": "4.6.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-helpers",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-helpers/issues",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "files": [
     "lib/*.js",
     "lib/*/*.js"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-helpers",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-helpers/issues",
-  "version": "4.6.0",
+  "version": "4.6.0-beta.0",
   "files": [
     "lib/*.js",
     "lib/*/*.js"

--- a/src/eventproxy/index.js
+++ b/src/eventproxy/index.js
@@ -1,6 +1,7 @@
 import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
 import { invoke } from '../utils';
+import { getReactRootElement } from './utils';
 
 const RESIZE_RATE = 300;
 const SCROLL_RATE = 100;
@@ -25,6 +26,17 @@ const createEventSettings = () => {
   settingsMap.scroll = {
     emitter: global,
     wrapper(callback) { return throttle(callback, SCROLL_RATE); },
+  };
+
+  // React 17 changed where it attaches it's event listeners.
+  // React 16 attached all event listeners to document. React 17 attaches all event
+  // listeners to the react root node.
+  // Given an event handler of type 'click' attaches a global click handler onto
+  // document, the click event would bubble up to the newly attached document click
+  // handler (which is, in most cases, an unexpected bahvior). We can prevent this
+  // from attaching specific events to the react root node instead.
+  settingsMap.click = {
+    emitter: getReactRootElement(global.document),
   };
 
   defaultSettings.emitter = global.document;

--- a/src/eventproxy/index.js
+++ b/src/eventproxy/index.js
@@ -1,7 +1,6 @@
 import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
 import { invoke } from '../utils';
-import { getReactRootElement } from './utils';
 
 const RESIZE_RATE = 300;
 const SCROLL_RATE = 100;
@@ -36,7 +35,7 @@ const createEventSettings = () => {
   // handler (which is, in most cases, an unexpected bahvior). We can prevent this
   // from attaching specific events to the react root node instead.
   settingsMap.click = {
-    emitter: getReactRootElement(global.document),
+    emitter: global.document.querySelector('#main'),
   };
 
   defaultSettings.emitter = global.document;

--- a/src/eventproxy/utils.js
+++ b/src/eventproxy/utils.js
@@ -1,1 +1,0 @@
-export const getReactRootElement = (document) => document.querySelector('#main');

--- a/src/eventproxy/utils.js
+++ b/src/eventproxy/utils.js
@@ -1,0 +1,1 @@
+export const getReactRootElement = (document) => document.querySelector('#main');


### PR DESCRIPTION
Important note: You cannot use eventproxy inside of an react portal. To be able to reliable use outside clicks inside portals, a react solution is needed.
