### PR TITLE
Add possible solution to the problem with event listeners executing right after being added

### DIFF
--- a/src/eventproxy/index.js
+++ b/src/eventproxy/index.js
@@ -106,7 +106,7 @@ const addListener = (event, callback) => {
   return removeEventListener;
 };
 
-const addListenerAsync = (event, callback, { immediately = false }) => {
+const addListenerAsync = (event, callback, { immediately = false } = {}) => {
   if (typeof event !== 'string') throw new Error('Event name required');
   if (typeof callback !== 'function') throw new Error('Listener function required');
   if (!isDOMAvailable) return noop;


### PR DESCRIPTION
https://favro.com/organization/aee06c3fe6503c804f507dd9/22c630cc02b09f2d6f98b8b3?card=Goo-39478

Some of our ContextMenus cannot be opened anymore.


Situation if `eventproxy` DOM listener is not yet attached:
- `ContextMenu` activates
- Attaches global click handler via `eventproxy('click', handler)`
- We attach our internal `eventproxy` click listener to our React root DOM node
- Newly attached listener does not get fired 

Situation if `eventproxy` DOM listener is already attached:
- `ContextMenu` activates
- Attaches global click handler via `eventproxy('click', handler)`
- We add a new handler to our internal click-handlers-list
- `eventproxy` click listener is next in line to fire: it picks up the newly added handler and executes it

I think that executing right after attaching is a very rarely desired case, so it makes sense to wait for a tick before adding new handlers.

(Note: Tested in CoreFE - fixes the issue)