### PR TITLE
Add solution to the problem with event listeners executing right after being added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nebenan-helpers",
-  "version": "4.6.1-beta.2",
+  "version": "4.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nebenan-helpers",
-  "version": "4.6.0-beta.0",
+  "version": "4.6.1-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-helpers",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-helpers/issues",
-  "version": "4.6.1-beta.2",
+  "version": "4.6.1",
   "files": [
     "lib/*.js",
     "lib/*/*.js"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-helpers",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-helpers/issues",
-  "version": "4.6.0-beta.0",
+  "version": "4.6.1-beta.2",
   "files": [
     "lib/*.js",
     "lib/*/*.js"

--- a/src/eventproxy/index.js
+++ b/src/eventproxy/index.js
@@ -4,6 +4,7 @@ import { invoke } from '../utils';
 
 const RESIZE_RATE = 300;
 const SCROLL_RATE = 100;
+const CALL_DELAY = 10;
 
 // ========================================================================================
 // Initialization
@@ -54,7 +55,10 @@ const getEventSettings = (event) => settingsMap[event] || defaultSettings;
 const handleEmitterEvent = (event) => {
   const eventData = getEventData(event.type);
   // Item may have been deleted during iteration cycle
-  Object.keys(eventData.listeners).forEach((id) => invoke(eventData.listeners[id], event));
+  Object.keys(eventData.listeners).forEach((id) => {
+    const handler = eventData.listeners[id];
+    if (handler && Date.now() - handler._attachedTime > CALL_DELAY) invoke(handler, event);
+  });
 };
 
 const attachEmitterHandler = (event, eventData, eventSettings) => {
@@ -95,6 +99,7 @@ const addListener = (event, callback) => {
   eventData.lastIndex += 1;
   const id = eventData.lastIndex;
   const handler = eventSettings.wrapper ? eventSettings.wrapper(callback) : callback;
+  handler._attachedTime = Date.now();
 
   eventData.listeners[id] = handler;
   eventData.listenersLength += 1;

--- a/src/eventproxy/index.js
+++ b/src/eventproxy/index.js
@@ -4,7 +4,7 @@ import { invoke } from '../utils';
 
 const RESIZE_RATE = 300;
 const SCROLL_RATE = 100;
-const CALL_DELAY = 10;
+const HANDLER_CALL_DELAY = 100;
 
 // ========================================================================================
 // Initialization
@@ -52,12 +52,25 @@ const getEventData = (event) => {
 
 const getEventSettings = (event) => settingsMap[event] || defaultSettings;
 
+// # This is a very dirty fix to a bad problem.
+// When attaching listeners of a given event type DURING the execution of an event handler
+// of this type, it needs to be prevented that the newly attached listener gets called immediately.
+// It is not a trivial task to get some code to execute after all event handlers for a
+// DOM element have been called. Some browser engines schedule tasks differently. Checking
+// for time is the most simple fix to the problem.
+//
+// How to prevent: Do not attach event listeners in event handlers.
+// https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/
+const isReadyForExecution = (handler) => (
+  handler && Date.now() - handler._attachedAt > HANDLER_CALL_DELAY
+);
+
 const handleEmitterEvent = (event) => {
   const eventData = getEventData(event.type);
   // Item may have been deleted during iteration cycle
   Object.keys(eventData.listeners).forEach((id) => {
     const handler = eventData.listeners[id];
-    if (handler && Date.now() - handler._attachedTime > CALL_DELAY) invoke(handler, event);
+    if (isReadyForExecution(handler)) handler(event);
   });
 };
 
@@ -99,7 +112,7 @@ const addListener = (event, callback) => {
   eventData.lastIndex += 1;
   const id = eventData.lastIndex;
   const handler = eventSettings.wrapper ? eventSettings.wrapper(callback) : callback;
-  handler._attachedTime = Date.now();
+  handler._attachedAt = Date.now();
 
   eventData.listeners[id] = handler;
   eventData.listenersLength += 1;


### PR DESCRIPTION
https://favro.com/organization/aee06c3fe6503c804f507dd9/22c630cc02b09f2d6f98b8b3?card=Goo-39478

Some of our ContextMenus cannot be opened anymore.


Situation if `eventproxy` DOM listener is not yet attached:
- `ContextMenu` activates
- Attaches global click handler via `eventproxy('click', handler)`
- We attach our internal `eventproxy` click listener to our React root DOM node
- Newly attached listener does not get fired 

Situation if `eventproxy` DOM listener is already attached:
- `ContextMenu` activates
- Attaches global click handler via `eventproxy('click', handler)`
- We add a new handler to our internal click-handlers-list
- `eventproxy` click listener is next in line to fire: it picks up the newly added handler and executes it
