### PR TITLE
Add fallback for click handler emitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nebenan-helpers",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-helpers",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-helpers/issues",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "files": [
     "lib/*.js",
     "lib/*/*.js"

--- a/src/eventproxy/index.js
+++ b/src/eventproxy/index.js
@@ -36,7 +36,7 @@ const createEventSettings = () => {
   // handler (which is, in most cases, an unexpected bahvior). We can prevent this
   // from attaching specific events to the react root node instead.
   settingsMap.click = {
-    emitter: global.document.querySelector('#main'),
+    emitter: global.document.querySelector('#main') || global.document,
   };
 
   defaultSettings.emitter = global.document;


### PR DESCRIPTION
All our apps use the root #main element. In storybook environments we don't have that element so the fallback is needed.